### PR TITLE
Error if MusicBrainz only has Stub CD entry

### DIFF
--- a/src/ripright.c
+++ b/src/ripright.c
@@ -213,6 +213,15 @@ static int doRip(void)
         Eject(gCdromDevice);
         return EXIT_FAILURE;
     }
+    else if(mbresult.releaseCount == 0)
+    {
+        LogErr("Only a CD Stub for discid=%s: Skipping rip\n"
+               "Please submit this disc to Musicbrainz: %s\n",
+               discId, discid_get_submission_url(disc));
+        Eject(gCdromDevice);
+        MbFree(&mbresult);
+        return EXIT_FAILURE;
+    }
 
     art_t *coverArt = x_calloc(sizeof(art_t), mbresult.releaseCount);
     bool   noArt = true;


### PR DESCRIPTION
If MusicBrainz has only a Stub entry for the CD then MbLookup will succeed but return a releaseCount of 0.  If this happens ripright should error, otherwise it will rip the CD but not output any FLAC files!

This is what the XML for a Stub entry looks like.  (I have added this CD to MusicBrainz to let me rip it, so this won't be reproducible now!)

```
(gdb) p (char*) buf
$11 = 0x555555786c00 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata xmlns=\"http://musicbrainz.org/ns/mmd-2.0#\"><cdstub id=\"2_CL1QsffWKFPk_I_EoPjDzUKU0-\"><title>a, Mokrenko, Morgunov / Prokofiev - Ivan the Terrible - Film music</title><artist>Riccardo Muti - Philharm. Orch., The Ambrisian Chorus; Arkhipov</artist><track-list count=\"26\"><track><title>Ivan the Terrible  Op116 - Prologue</title><length>51466</length></track><track><title>Ivan the Terrible  Op116 - 1. Overture and Chorus</title><length>201960</length></track><track><title>Ivan the Terrible Op116 - 2. March of the Young Ivan</title><length>100706</length></track><track><title>Ivan the Terrible Op116 - 3. Ocean-Sea</title><length>203093</length></track><track><title>Ivan the Terrible Op116 - 4. I will be Tsar!</title><length>43773</length></track><track><title>Ivan the Terrible Op116 - 5. God is wondrous!</title><length>77226</length></track><track><title>Ivan the Terrible Op116 - 6. Long life!</title><length>149640</length></track><track><title>Ivan the Terrible Op116 - 7. The Holy Fool</title><length>159400</length></track><track><title>Ivan the Terrible Op116 - 8. Long Life!</title><length>67026</length></track><track><title>Ivan the Terrible Op116 - 9. The Holy Fool</title><length>124973</length></track><track><title>Ivan the Terrible Op116 - 10.The Swan</title><length>58000</length></track><track><title>Ivan the Terrible Op116 - 11. Celebration Song</title><length>192226</length></track><track><title>Ivan the Terrible Op116 - 12. The Swan</title><length>99640</length></track><track><title>Ivan the Terrible Op116 - 13. On the Bones of the Enemy</title><length>76026</length></track><track><title>Ivan the Terrible Op116 - 14. The tartars</title><length>96306</length></track><track><title>Ivan the Terrible Op116 - 15. The Gunners</title><length>146293</length></track><track><title>Ivan the Terrible Op116 - 16. The Storming of Kazan</title><length>587173</length></track><track><title>Ivan the Terrible Op116 - 17. Ivan's Appeal to the Boya</title><length>486293</length></track><track><title>Ivan the Terrible Op116 - 18. Yefrosinia &amp; Anastasia</title><length>243840</length></track><track><title>Ivan the Terrible Op116 - 19. Song about the Beaver</title><length>185226</length></track><track><title>Ivan the Terrible Op116 - 20. Ivan at Anastasia's Bier</title><length>143906</length></track><track><title>Ivan the Terrible Op116 - 21. Chorus of the Oprichniki</title><length>93293</length></track><track><title>Ivan the Terrible Op116 - 22.  The Oprichniki Oath of Lo</title><length>308840</length></track><track><title>Ivan the Terrible Op116 - 23. Feodor Basmanov's Song</title><length>109160</length></track><track><title>Ivan the Terrible Op116 - 24. Dabce of the Oprichniki</title><length>120000</length></track><track><title>Ivan the Terrible Op116 - 25. Finale</title><length>324440</length></track></track-list></cdstub></metadata>\n"
```